### PR TITLE
Try to fix lag issue when switching between a lot of buffers

### DIFF
--- a/plugin/troll_stopper.vim
+++ b/plugin/troll_stopper.vim
@@ -296,7 +296,10 @@ function! s:TrollStop(line1, line2)
   call cursor(line, col)
 endfunction
 
-autocmd BufEnter * call <SID>HighlighTrolling()
+augroup highlight
+	autocmd!
+	autocmd BufNewFile,BufRead * call <SID>HighlighTrolling()
+augroup END
 
 command! -range=% TrollStop call <SID>TrollStop(<line1>, <line2>)
 


### PR DESCRIPTION
Hello,

Thank you for this very useful vim plugin.
I'm new to github and I don't know a lot about vimscript, however it seems to me that the plugin causes some lag when I switch between a lot of buffers.

I think it comes from the fact that the more I switch between buffers the more the `HighlighTrolling()` function piles highlight patterns.

At least, that's what I've been told on [vi.stackexchange.com](https://vi.stackexchange.com/questions/5316/fixing-lag-due-to-vim-troll-stopper-plugin).

I fixed the issue by changing the event that triggers the autocommand that calls the function from `BufEnter` to `BufNewFile,BufRead`.
It is not relevant to the issue, but I also wrapped the autocmd inside an augroup and cleared it with `autocmd!`.

I don't know if it's correct, but it seems to work on my machine, so I thought I could propose you this pull request.

Thank you for having read my message, have a good day.
