### PR TITLE
change regex from /a|b|c|d/ to [abcd]

### DIFF
--- a/plugin/troll_stopper.vim
+++ b/plugin/troll_stopper.vim
@@ -298,8 +298,8 @@ let s:invisible_chars_map = {
 
 let s:all_chars_map = extend(extend({}, s:visible_chars_map), s:invisible_chars_map)
 
-let s:visible_chars_regex = join(keys(s:visible_chars_map), '\|')
-let s:invisible_chars_regex = join(keys(s:invisible_chars_map), '\|')
+let s:visible_chars_regex = '[' . join(keys(s:visible_chars_map), '') . ']'
+let s:invisible_chars_regex = '[' . join(keys(s:invisible_chars_map), '') . ']'
 
 function! s:HighlighTrolling()
   if !exists('w:highlighted_troll_stopper')


### PR DESCRIPTION
Seems to reduce a lot of lag (#7 ?), based on my totally unscientific test of scrolling through some large files.