### PR TITLE
Fix bug about colorscheme

### DIFF
--- a/plugin/troll_stopper.vim
+++ b/plugin/troll_stopper.vim
@@ -12,9 +12,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 if hlexists('TrollStopper') == 0
-  highlight link TrollStopper Error
+  highlight default link TrollStopper Error
   highlight Conceal NONE
-  highlight link Conceal Error
+  highlight default link Conceal Error
 endif
 
 if !exists("g:troll_stopper_conceal")


### PR DESCRIPTION
```vim
#!/usr/bin/env -S vi ${HOME}/.local/share/nvim/repos/github.com/vim-utils/vim-troll-stopper/hello.c -u
" $ uname -r
" 5.19.7-arch1-1
" $ has
" ✓ vi 0.7.2
" $ cat test.vim
set runtimepath=$VIMRUNTIME
set runtimepath+=~/.local/share/nvim/repos/github.com/vim-utils/vim-troll-stopper
" $ chmod +x test.vim
" $ ./test.vim
```

![Screenshot from 2022-10-14 16-02-31](https://user-images.githubusercontent.com/32936898/195794989-6fcdf394-fedc-467c-b6ef-22571d713b8c.png)

Then `colorscheme default`:

![Screenshot from 2022-10-14 16-03-03](https://user-images.githubusercontent.com/32936898/195795000-fe3d720d-3007-47ea-ac35-3f2b278c1a10.png)

This PR fixes this bug.
